### PR TITLE
Focus searchBox when navigating to Search panel

### DIFF
--- a/Baconit/Panels/Search.xaml.cs
+++ b/Baconit/Panels/Search.xaml.cs
@@ -80,7 +80,7 @@ namespace Baconit.Panels
 
         public void OnNavigatingTo()
         {
-            // Ignore for now
+            ui_searchBox.Focus(FocusState.Programmatic);
         }
 
         public void OnNavigatingFrom()


### PR DESCRIPTION
Just a quick improvement to have the search box focused when the Search panel is navigated to (with the future goal of being able to initiate search anywhere in the app by just typing)