### PR TITLE
Clean up various minor issues with the UI

### DIFF
--- a/BaconBackend/DataObjects/Post.cs
+++ b/BaconBackend/DataObjects/Post.cs
@@ -354,7 +354,7 @@ namespace BaconBackend.DataObjects
         {
             get
             {
-                return IsSaved ? "Unsave Post" : "Save Post";
+                return IsSaved ? "Unsave post" : "Save post";
             }
         }
 
@@ -366,7 +366,7 @@ namespace BaconBackend.DataObjects
         {
             get
             {
-                return IsHidden ? "Unhide Post" : "Hide Post";
+                return IsHidden ? "Unhide post" : "Hide post";
             }
         }
 

--- a/Baconit/Panels/FlipViewPanel.xaml
+++ b/Baconit/Panels/FlipViewPanel.xaml
@@ -7,7 +7,7 @@
              xmlns:local="using:Baconit.Panels"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              d:DesignHeight="800"
-             d:DesignWidth="1280"
+             d:DesignWidth="600"
              mc:Ignorable="d">
 
     <UserControl.Resources>

--- a/Baconit/Panels/MessageInbox.xaml
+++ b/Baconit/Panels/MessageInbox.xaml
@@ -69,10 +69,12 @@
 
         <!--  Message Header  -->
         <StackPanel Grid.Row="0"
-                    Background="#333333"
+                    Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
                     Orientation="Horizontal"
                     Padding="12">
-            <TextBlock VerticalAlignment="Bottom" Text="Message Inbox" />
+            <TextBlock VerticalAlignment="Bottom"
+                       Text="MESSAGE INBOX"
+                       FontWeight="Bold"/>
         </StackPanel>
 
         <!--  The main message list  -->

--- a/Baconit/Panels/Search.xaml
+++ b/Baconit/Panels/Search.xaml
@@ -132,9 +132,11 @@
 
         <!--  Subreddit Header  -->
         <Grid Grid.Row="0"
-              Background="#333333"
+              Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
               Padding="12">
-            <TextBlock VerticalAlignment="Bottom" Text="Search" />
+            <TextBlock VerticalAlignment="Bottom"
+                       Text="SEARCH"
+                       FontWeight="Bold"/>
         </Grid>
 
         <!--  Search Header  -->

--- a/Baconit/Panels/Settings.xaml
+++ b/Baconit/Panels/Settings.xaml
@@ -16,10 +16,12 @@
 
         <!--  Subreddit Header  -->
         <StackPanel Grid.Row="0"
-                    Background="#333333"
+                    Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
                     Orientation="Horizontal"
                     Padding="12">
-            <TextBlock VerticalAlignment="Bottom" Text="Settings" />
+            <TextBlock VerticalAlignment="Bottom"
+                       Text="SETTINGS"
+                       FontWeight="Bold"/>
         </StackPanel>
 
         <ListView x:Name="ui_settingsList"

--- a/Baconit/Panels/Settings.xaml.cs
+++ b/Baconit/Panels/Settings.xaml.cs
@@ -27,11 +27,11 @@ namespace Baconit.Panels
             this.InitializeComponent();
 
             // Add the settings to the list
-            m_settingsList.Add("Subreddit View");
-            m_settingsList.Add("Flip View");
-            m_settingsList.Add("Updating, Lock Screen, and Desktop Images");
+            m_settingsList.Add("Subreddit view");
+            m_settingsList.Add("Flip view");
+            m_settingsList.Add("Updating, lock screen and desktop images");
             m_settingsList.Add("About");
-            m_settingsList.Add("Privacy Policy");
+            m_settingsList.Add("Privacy policy");
 
             // Set the list
             ui_settingsList.ItemsSource = m_settingsList;

--- a/Baconit/Panels/SettingsPanels/AboutSettings.xaml
+++ b/Baconit/Panels/SettingsPanels/AboutSettings.xaml
@@ -16,102 +16,106 @@
 
         <!--  Subreddit Header  -->
         <StackPanel Grid.Row="0"
-                    Background="#333333"
                     Orientation="Horizontal"
+                    Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
                     Padding="12">
-            <TextBlock VerticalAlignment="Bottom" Text="About" />
+            <TextBlock VerticalAlignment="Bottom"
+                       Text="ABOUT"
+                       FontWeight="Bold"/>
         </StackPanel>
 
-        <Grid Grid.Row="1">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
+        <ScrollViewer Grid.Row="1">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
 
 
-            <Grid Margin="12">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="auto" />
-                    <ColumnDefinition Width="auto" />
-                </Grid.ColumnDefinitions>
+                <Grid Margin="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="auto" />
+                        <ColumnDefinition Width="auto" />
+                    </Grid.ColumnDefinitions>
 
-                <Grid Width="70"
-                      Height="70"
-                      Background="{StaticResource SystemControlBackgroundAccentBrush}"
-                      Tapped="Logo_Tapped">
-                    <Image Margin="8" Source="ms-appx:///Assets/Settings/AboutBaconitIcon.png" />
+                    <Grid Width="70"
+                          Height="70"
+                          Background="{StaticResource SystemControlBackgroundAccentBrush}"
+                          Tapped="Logo_Tapped">
+                        <Image Margin="8" Source="ms-appx:///Assets/Settings/AboutBaconitIcon.png" />
+                    </Grid>
+
+                    <StackPanel Grid.Column="1">
+                        <TextBlock Margin="8,-10,8,0"
+                                   FontSize="32"
+                                   Text="Baconit" />
+                        <TextBlock x:Name="ui_buildString"
+                                   Margin="8,0,0,0"
+                                   Text="Build:" />
+
+                    </StackPanel>
                 </Grid>
 
-                <StackPanel Grid.Column="1">
-                    <TextBlock Margin="8,-10,8,0"
-                               FontSize="32"
-                               Text="Baconit" />
-                    <TextBlock x:Name="ui_buildString"
-                               Margin="8,0,0,0"
-                               Text="Build:" />
+                <TextBlock Grid.Row="1"
+                           Margin="12"
+                           Text="Baconit is THE BEST open source reddit client on Windows. Baconit was originally written in 2010 for Windows Phone 7.5 by Quinn Damerell. It remained a closed sourced Silverlight app until the launch of Windows 10. At that point Quinn rewrote the entire app from the ground up on the new Universal App platform, enabling it to run on all Windows devices. It was released and opened sourced on to the world on November 13, 2015. Many thanks to all who have contributed."
+                           TextWrapping="Wrap" />
 
-                </StackPanel>
+                <Grid Grid.Row="2"
+                      Margin="12"
+                      Background="Transparent"
+                      Tapped="RateAndReview_Tapped">
+                    <TextBlock Text="Rate and Review" />
+                </Grid>
+
+                <Grid Grid.Row="3"
+                      Margin="12"
+                      Background="Transparent"
+                      Tapped="ShowSource_Tapped">
+                    <TextBlock Text="Check out the source code" />
+                </Grid>
+
+                <Grid Grid.Row="4"
+                      Margin="12"
+                      Background="Transparent"
+                      Tapped="OpenBaconitSub_Tapped">
+                    <TextBlock Text="Baconit's Subreddit" />
+                </Grid>
+
+                <Grid Grid.Row="5"
+                      Margin="12"
+                      Background="Transparent"
+                      Tapped="Website_Tapped">
+                    <TextBlock Text="Baconit's Website" />
+                </Grid>
+
+                <Grid Grid.Row="6"
+                      Margin="12"
+                      Background="Transparent"
+                      Tapped="Facebook_Tapped">
+                    <TextBlock Text="Facebook" />
+                </Grid>
+
+                <Grid Grid.Row="7"
+                      Margin="12"
+                      Background="Transparent"
+                      Tapped="Twitter_Tapped">
+                    <TextBlock Text="Twitter" />
+                </Grid>
+
+                <HyperlinkButton Grid.Row="7"
+                                 Margin="11,6"
+                                 VerticalAlignment="Bottom"
+                                 Content="QuinnDamerell.com"
+                                 Foreground="White"
+                                 NavigateUri="http://www.quinndamerell.com" />
             </Grid>
-
-            <TextBlock Grid.Row="1"
-                       Margin="12"
-                       Text="Baconit is THE BEST open source reddit client on Windows. Baconit was originally written in 2010 for Windows Phone 7.5 by Quinn Damerell. It remained a closed sourced Silverlight app until the launch of Windows 10. At that point Quinn rewrote the entire app from the ground up on the new Universal App platform, enabling it to run on all Windows devices. It was released and opened sourced on to the world on November 13, 2015. Many thanks to all who have contributed."
-                       TextWrapping="Wrap" />
-
-            <Grid Grid.Row="2"
-                  Margin="12"
-                  Background="Transparent"
-                  Tapped="RateAndReview_Tapped">
-                <TextBlock Text="Rate and Review" />
-            </Grid>
-
-            <Grid Grid.Row="3"
-                  Margin="12"
-                  Background="Transparent"
-                  Tapped="ShowSource_Tapped">
-                <TextBlock Text="Check out the source code" />
-            </Grid>
-
-            <Grid Grid.Row="4"
-                  Margin="12"
-                  Background="Transparent"
-                  Tapped="OpenBaconitSub_Tapped">
-                <TextBlock Text="Baconit's Subreddit" />
-            </Grid>
-
-            <Grid Grid.Row="5"
-                  Margin="12"
-                  Background="Transparent"
-                  Tapped="Website_Tapped">
-                <TextBlock Text="Baconit's Website" />
-            </Grid>
-
-            <Grid Grid.Row="6"
-                  Margin="12"
-                  Background="Transparent"
-                  Tapped="Facebook_Tapped">
-                <TextBlock Text="Facebook" />
-            </Grid>
-
-            <Grid Grid.Row="7"
-                  Margin="12"
-                  Background="Transparent"
-                  Tapped="Twitter_Tapped">
-                <TextBlock Text="Twitter" />
-            </Grid>
-
-            <HyperlinkButton Grid.Row="7"
-                             Margin="11,6"
-                             VerticalAlignment="Bottom"
-                             Content="QuinnDamerell.com"
-                             Foreground="White"
-                             NavigateUri="http://www.quinndamerell.com" />
-        </Grid>
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/Baconit/Panels/SettingsPanels/BackgroundUpdatingSettings.xaml
+++ b/Baconit/Panels/SettingsPanels/BackgroundUpdatingSettings.xaml
@@ -16,16 +16,18 @@
 
         <!--  Header  -->
         <StackPanel Grid.Row="0"
-                    Background="#333333"
+                    Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
                     Orientation="Horizontal"
                     Padding="12">
-            <TextBlock VerticalAlignment="Bottom" Text="Updating and Lock Screen Images" />
+            <TextBlock VerticalAlignment="Bottom"
+                       Text="UPDATING AND LOCK SCREEN IMAGES"
+                       FontWeight="Bold"/>
         </StackPanel>
 
         <ScrollViewer Grid.Row="1">
             <StackPanel Grid.Row="1" Margin="12">
                 <TextBlock Margin="0,0,0,12"
-                           Text="These settings allows Baconit to automatically update your lock screen image and desktop wallpaper from images on any subreddit. On a mobile device, the desktop wallpaper is the image behind your tiles. These settings don't roam so you can set them per device."
+                           Text="These settings allow Baconit to automatically update your lock screen image and desktop wallpaper from images on any subreddit. On a mobile device, the desktop wallpaper is the image behind your tiles. These settings don't roam so you can set them per device."
                            TextWrapping="Wrap" />
 
                 <TextBlock Margin="0,0,0,12"
@@ -36,23 +38,23 @@
                 <TextBlock Text="Allow Baconit to update my lock screen image." TextWrapping="Wrap" />
                 <ToggleSwitch x:Name="ui_enableLockScreen" Toggled="ToggleSwitch_Toggled" />
                 <TextBlock Margin="0,12,0,0"
-                           Text="Allow Baconit to update my desktop wallpaper."
+                           Text="Allow Baconit to update my desktop wallpaper"
                            TextWrapping="Wrap" />
                 <ToggleSwitch x:Name="ui_enableDesktop" Toggled="ToggleSwitch_Toggled" />
                 <TextBlock Margin="0,12,0,0"
-                           Text="Subreddit to source images from for lock screen."
+                           Text="Subreddit to source images from for lock screen"
                            TextWrapping="Wrap" />
                 <ComboBox x:Name="ui_lockScreenSource"
                           Margin="0,8,0,8"
                           SelectionChanged="ComboBox_SelectionChanged" />
                 <TextBlock Margin="0,12,0,0"
-                           Text="Subreddit to source images from for desktop wallpaper."
+                           Text="Subreddit to source images from for desktop wallpaper"
                            TextWrapping="Wrap" />
                 <ComboBox x:Name="ui_desktopSource"
                           Margin="0,8,0,8"
                           SelectionChanged="ComboBox_SelectionChanged" />
                 <TextBlock Margin="0,12,0,0"
-                           Text="Image update frequency."
+                           Text="Image update frequency"
                            TextWrapping="Wrap" />
                 <ComboBox x:Name="ui_imageFrequency"
                           Margin="0,8,0,8"
@@ -61,12 +63,12 @@
                 <TextBlock x:Name="ui_lastAttemptedUpdate"
                            Margin="0,12,0,0"
                            Foreground="#BBFFFFFF"
-                           Text="Last Attempted Update:"
+                           Text="Last attempted update:"
                            TextWrapping="Wrap" />
                 <TextBlock x:Name="ui_lastSuccessfulUpdate"
                            Margin="0,12,0,0"
                            Foreground="#BBFFFFFF"
-                           Text="Last Successful Update:"
+                           Text="Last successful update:"
                            TextWrapping="Wrap" />
             </StackPanel>
         </ScrollViewer>

--- a/Baconit/Panels/SettingsPanels/BackgroundUpdatingSettings.xaml.cs
+++ b/Baconit/Panels/SettingsPanels/BackgroundUpdatingSettings.xaml.cs
@@ -98,8 +98,8 @@ namespace Baconit.Panels.SettingsPanels
             ui_imageFrequency.ItemsSource = m_updateFrequencys;
             ui_imageFrequency.SelectedIndex = FrequencySettingToListIndex(App.BaconMan.BackgroundMan.ImageUpdaterMan.UpdateFrquency);
 
-            ui_lastSuccessfulUpdate.Text = "Last Successful Update: " + (App.BaconMan.BackgroundMan.LastSuccessfulUpdate.Equals(new DateTime(0)) ? "Never" : App.BaconMan.BackgroundMan.LastSuccessfulUpdate.ToString("g"));
-            ui_lastAttemptedUpdate.Text = "Last Attempted Update: " + (App.BaconMan.BackgroundMan.LastAttemptedUpdate.Equals(new DateTime(0)) ? "Never" : App.BaconMan.BackgroundMan.LastAttemptedUpdate.ToString("g"));
+            ui_lastSuccessfulUpdate.Text = "Last successful update: " + (App.BaconMan.BackgroundMan.LastSuccessfulUpdate.Equals(new DateTime(0)) ? "never" : App.BaconMan.BackgroundMan.LastSuccessfulUpdate.ToString("g"));
+            ui_lastAttemptedUpdate.Text = "Last attempted update: " + (App.BaconMan.BackgroundMan.LastAttemptedUpdate.Equals(new DateTime(0)) ? "never" : App.BaconMan.BackgroundMan.LastAttemptedUpdate.ToString("g"));
 
             m_ingoreUpdates = false;
 

--- a/Baconit/Panels/SettingsPanels/DeveloperSettings.xaml
+++ b/Baconit/Panels/SettingsPanels/DeveloperSettings.xaml
@@ -16,14 +16,16 @@
 
         <!--  Header  -->
         <StackPanel Grid.Row="0"
-                    Background="#333333"
+                    Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
                     Orientation="Horizontal"
                     Padding="12">
-            <TextBlock VerticalAlignment="Bottom" Text="Developer Settings" />
+            <TextBlock VerticalAlignment="Bottom"
+                       Text="DEVELOPER SETTINGS"
+                       FontWeight="Bold"/>
         </StackPanel>
 
         <StackPanel Grid.Row="1" Margin="12">
-            <TextBlock Text="Verbose Debugging. To the average user this will pop up a lot of useless dialog boxes." TextWrapping="Wrap" />
+            <TextBlock Text="Verbose debugging. To the average user this will pop up a lot of useless dialog boxes." TextWrapping="Wrap" />
             <ToggleSwitch x:Name="ui_debuggingOn" Toggled="DebuggingOn_Toggled" />
         </StackPanel>
     </Grid>

--- a/Baconit/Panels/SettingsPanels/FlipViewSettings.xaml
+++ b/Baconit/Panels/SettingsPanels/FlipViewSettings.xaml
@@ -16,24 +16,26 @@
 
         <!--  Flipview Header  -->
         <StackPanel Grid.Row="0"
-                    Background="#333333"
+                    Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
                     Orientation="Horizontal"
                     Padding="12">
-            <TextBlock VerticalAlignment="Bottom" Text="Flip View Settings" />
+            <TextBlock VerticalAlignment="Bottom"
+                       Text="FLIP VIEW SETTINGS"
+                       FontWeight="Bold"/>
         </StackPanel>
 
         <StackPanel Grid.Row="1" Margin="12">
-            <TextBlock Text="Preload comments for the current post." TextWrapping="Wrap" />
+            <TextBlock Text="Preload comments for the current post" TextWrapping="Wrap" />
             <ToggleSwitch x:Name="ui_preLoadComments"
                           Margin="0,0,0,8"
                           Toggled="PreLoadComments_Toggled" />
-            <TextBlock Text="Show UI Help Tips." TextWrapping="Wrap" />
+            <TextBlock Text="Show UI help tips" TextWrapping="Wrap" />
             <ToggleSwitch x:Name="ui_showHelpTips"
                           Margin="0,0,0,8"
                           Toggled="ShowHelpTips_Toggled" />
 
             <TextBlock Margin="0,0,0,8"
-                       Text="NSFW screen blocking strategy."
+                       Text="NSFW screen blocking strategy"
                        TextWrapping="Wrap" />
             <ComboBox x:Name="ui_flipViewNsfwType" SelectionChanged="FlipViewNsfwType_SelectionChanged">
                 <ComboBoxItem>Always</ComboBoxItem>

--- a/Baconit/Panels/SettingsPanels/SubredditViewSettings.xaml
+++ b/Baconit/Panels/SettingsPanels/SubredditViewSettings.xaml
@@ -16,18 +16,20 @@
 
         <!--  Subreddit Header  -->
         <StackPanel Grid.Row="0"
-                    Background="#333333"
+                    Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
                     Orientation="Horizontal"
                     Padding="12">
-            <TextBlock VerticalAlignment="Bottom" Text="Subreddit View Settings" />
+            <TextBlock VerticalAlignment="Bottom"
+                       Text="SUBREDDIT VIEW SETTINGS"
+                       FontWeight="Bold"/>
         </StackPanel>
 
         <StackPanel Grid.Row="1" Margin="12">
-            <TextBlock Text="Subreddit to show when the app opens." TextWrapping="Wrap" />
+            <TextBlock Text="Subreddit to show when the app opens" TextWrapping="Wrap" />
             <ComboBox x:Name="ui_defaultSubreddit"
                       Margin="0,8,12,18"
                       SelectionChanged="DefaultSubreddit_SelectionChanged" />
-            <TextBlock Text="Show full post titles in subreddit view." TextWrapping="Wrap" />
+            <TextBlock Text="Show full post titles in subreddit view" TextWrapping="Wrap" />
             <ToggleSwitch x:Name="ui_showFullTitles" Toggled="ShowFullTitles_Toggled" />
         </StackPanel>
     </Grid>

--- a/Baconit/Panels/SubredditPanel.xaml
+++ b/Baconit/Panels/SubredditPanel.xaml
@@ -82,12 +82,12 @@
 
 
         <DataTemplate x:Key="SubredditItemItemDataTemplate">
-            <Grid Margin="0,0,6,15"
+            <Grid Margin="0,8,0,8"
                   Background="Transparent"
                   Holding="Post_Holding"
                   RightTapped="Post_RightTapped">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="45" />
+                    <ColumnDefinition Width="50" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
@@ -101,44 +101,31 @@
                 </FlyoutBase.AttachedFlyout>
 
                 <StackPanel Grid.Column="0"
-                            Margin="0,0,0,0"
                             VerticalAlignment="Top"
                             Orientation="Vertical">
                     <StackPanel Margin="0,0,0,0"
-                                Background="#00000000"
+                                Background="Transparent"
                                 Tapped="UpVote_Tapped">
-                        <StackPanel Width="45"
-                                    Height="35"
+                        <StackPanel Height="35"
                                     Margin="0,5,0,0"
-                                    HorizontalAlignment="Left"
-                                    Orientation="Vertical">
-                            <Polygon HorizontalAlignment="Center"
-                                     Fill="{Binding UpVoteColor}"
-                                     Points="0,15 20,15 10,0" />
-                            <Rectangle Width="8"
-                                       Height="9"
-                                       Margin="0,-1,1,0"
-                                       HorizontalAlignment="Center"
-                                       Fill="{Binding UpVoteColor}" />
+                                    HorizontalAlignment="Center">
+                            <SymbolIcon HorizontalAlignment="Center"
+                                        Symbol="Up"
+                                        Foreground="{Binding UpVoteColor}"/>
                         </StackPanel>
                     </StackPanel>
                     <TextBlock Margin="0,-9,0,0"
                                HorizontalAlignment="Center"
                                Text="{Binding Score}" />
                     <StackPanel Margin="0,-9,0,0"
-                                Background="#00000000"
+                                Background="Transparent"
                                 Tapped="DownVote_Tapped">
                         <StackPanel Height="35"
-                                    Margin="0,8,0,0"
-                                    Orientation="Vertical">
-                            <Rectangle Width="7"
-                                       Height="9"
-                                       Margin="0,6,0,-1"
-                                       HorizontalAlignment="Center"
-                                       Fill="{Binding DownVoteColor}" />
-                            <Polygon HorizontalAlignment="Center"
-                                     Fill="{Binding DownVoteColor}"
-                                     Points="0,0 20,0 10,15" />
+                                    Margin="0,16,0,0">
+                            <FontIcon HorizontalAlignment="Center"
+                                      Glyph=""
+                                        Foreground="{Binding DownVoteColor}"/>
+
                         </StackPanel>
                     </StackPanel>
                 </StackPanel>
@@ -202,11 +189,9 @@
                 <StackPanel Grid.Column="2"
                             Margin="0,4,0,0"
                             VerticalAlignment="Top"
-                            Background="{ThemeResource SystemControlBackgroundAccentBrush}"
                             Tapped="PostTitle_Tapped"
                             Visibility="{Binding ImageVisibility}">
                     <Image Width="70"
-                           Margin="3,3,3,3"
                            HorizontalAlignment="Right"
                            Source="{Binding Image}" />
                 </StackPanel>
@@ -223,26 +208,30 @@
         </Grid.RowDefinitions>
 
         <!--  Subreddit Header  -->
-        <Grid Grid.Row="0" Background="Transparent">
+        <Grid Grid.Row="0"
+              Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="auto" />
             </Grid.ColumnDefinitions>
-            <Grid Background="Transparent" Tapped="SubredditHeader_Tapped">
-                <TextBlock x:Name="ui_subredditName"
-                           Margin="12,12,0,12"
-                           VerticalAlignment="Bottom"
-                           Text="Baconit" />
+            <Grid Background="Transparent"
+                  Tapped="SubredditHeader_Tapped">
+                <TextBlock Margin="12"
+                           VerticalAlignment="Center">
+                    <!-- Hamburger -->
+                    <Run FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                         Text="  "/>
+                    <Run x:Name="ui_subredditName"
+                         Text="BACONIT"
+                         FontWeight="Bold"/>
+                </TextBlock>
             </Grid>
 
 
-            <StackPanel Grid.Column="1"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Bottom"
-                        Background="Transparent"
-                        Orientation="Horizontal"
-                        Padding="12"
-                        Tapped="Sort_Tapped">
+            <Border Grid.Column="1"
+                    Background="Transparent"
+                    Padding="16,0"
+                    Tapped="Sort_Tapped">
                 <FlyoutBase.AttachedFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Click="SortMenuItem_Click" Text="Hot" />
@@ -252,18 +241,19 @@
                         <MenuFlyoutItem Click="SortMenuItem_Click" Text="Top" />
                     </MenuFlyout>
                 </FlyoutBase.AttachedFlyout>
-                <TextBlock Margin="0,0,2,0"
-                           VerticalAlignment="Bottom"
-                           FontSize="12"
-                           Foreground="#989898"
-                           Text="Sort:" />
-                <TextBlock x:Name="ui_sortText"
-                           VerticalAlignment="Bottom"
-                           FontSize="12"
-                           Foreground="{ThemeResource SystemControlBackgroundAccentBrush}"
-                           Text="Hot" />
-            </StackPanel>
+
+                <TextBlock Foreground="#A5A5A5"
+                           VerticalAlignment="Center">
+                    <Run x:Name="ui_sortText"
+                         Text="HOT"/>
+                    <!-- Down caret -->
+                    <Run Text="   &#xE0E5;"
+                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                         FontSize="12"/>
+                </TextBlock>
+            </Border>
         </Grid>
+        
         <!--  Loading indicator  -->
         <ProgressBar x:Name="ui_progressBar"
                      Grid.Row="0"
@@ -279,7 +269,6 @@
                                             ItemTemplate="{StaticResource SubredditItemItemDataTemplate}"
                                             Padding="0,0,12,0"
                                             SelectionChanged="PostList_SelectionChanged">
-
             <ListView.ItemContainerTransitions>
                 <TransitionCollection>
                     <EntranceThemeTransition IsStaggeringEnabled="True" />

--- a/Baconit/Panels/SubredditPanel.xaml.cs
+++ b/Baconit/Panels/SubredditPanel.xaml.cs
@@ -166,7 +166,7 @@ namespace Baconit.Panels
             SetPosts(0, m_collector.GetCurrentPosts(), true);
 
             // Setup the UI with the name.
-            ui_subredditName.Text = $"/r/{m_subreddit.DisplayName}";
+            ui_subredditName.Text = m_subreddit.DisplayName.ToUpper();
         }
 
         #endregion


### PR DESCRIPTION
For mobile, MS seems to be standardizing on uppercase page titles (see settings, email, calendar and calculator apps), so I've changed the page titles to uppercase.  I've also fixed the inconsistent capitalization and removed extraneous full stops.  Plus I replaced the fat upvote and downvote icons with skinny Windows 10 versions.  I also added a hamburger icon to the subreddit page title (to show that it pops out the sidebar) and improved the sort order UI widget in the subreddit page title.