### PR TITLE
Prevent "infinite" votes within the app

### DIFF
--- a/BaconBackend/Collectors/CommentCollector.cs
+++ b/BaconBackend/Collectors/CommentCollector.cs
@@ -237,31 +237,28 @@ namespace BaconBackend.Collectors
             }
 
             // Update the like status
-            if (action == PostVoteAction.UpVote)
+            bool likesAction = action == PostVoteAction.UpVote;
+            int voteMultiplier = action == PostVoteAction.UpVote ? 1 : -1;
+            if(collectionComment.Likes.HasValue)
             {
-                if (collectionComment.Likes.HasValue && collectionComment.Likes.Value)
+                if(collectionComment.Likes.Value == likesAction)
                 {
+                    // duplicate vote would undo the action
                     collectionComment.Likes = null;
-                    collectionComment.Score--;
+                    collectionComment.Score -= voteMultipler;
                 }
                 else
                 {
-                    collectionComment.Likes = true;
-                    collectionComment.Score++;
+                    // opposite vote, takes into account previous vote
+                    collectionComment.Likes = likesAction;
+                    collectionComment.Score += 2 * voteMultiplier
                 }
             }
             else
             {
-                if (collectionComment.Likes.HasValue && !collectionComment.Likes.Value)
-                {
-                    collectionComment.Likes = null;
-                    collectionComment.Score++;
-                }
-                else
-                {
-                    collectionComment.Likes = false;
-                    collectionComment.Score--;
-                }
+                // first vote
+                collectionComment.Likes = likesAction;
+                collectionComment.Score += voteMultiplier;
             }
 
             // Fire off that a update happened.

--- a/BaconBackend/Collectors/SubredditCollector.cs
+++ b/BaconBackend/Collectors/SubredditCollector.cs
@@ -207,33 +207,30 @@ namespace BaconBackend.Collectors
             }
 
             // Update the like status
-            if(action == PostVoteAction.UpVote)
+            bool likesAction = action == PostVoteAction.UpVote;
+            int voteMultiplier = action == PostVoteAction.UpVote ? 1 : -1;
+            if(collectionPost.Likes.HasValue)
             {
-                if(collectionPost.Likes.HasValue && collectionPost.Likes.Value)
+                if(collectionPost.Likes.Value == likesAction)
                 {
+                    // duplicate vote would undo the action
                     collectionPost.Likes = null;
-                    collectionPost.Score--;
+                    collectionPost.Score -= voteMultipler;
                 }
                 else
                 {
-                    collectionPost.Likes = true;
-                    collectionPost.Score++;
+                    // opposite vote, takes into account previous vote
+                    collectionPost.Likes = likesAction;
+                    collectionPost.Score += 2 * voteMultiplier
                 }
             }
             else
             {
-                if (collectionPost.Likes.HasValue && !collectionPost.Likes.Value)
-                {
-                    collectionPost.Likes = null;
-                    collectionPost.Score++;
-                }
-                else
-                {
-                    collectionPost.Likes = false;
-                    collectionPost.Score--;
-                }
+                // first vote
+                collectionPost.Likes = likesAction;
+                collectionPost.Score += voteMultiplier;
             }
-
+            
             // Fire off that a update happened.
             FireCollectionUpdated(postPosition, new List<Post>() { collectionPost }, false, false);
 


### PR DESCRIPTION
The basic idea being that:
- Re-clicking same button undo's the vote
- Casting an opposite post vote changes score by 2
