### PR TITLE
 Possible fix for parsing Subreddits's data when there are other objects (other than "data") inside a Subreddit's JSON (causing some Subreddits to be not possible to load from the app)

### DIFF
--- a/BaconBackend/BaconBackend.csproj
+++ b/BaconBackend/BaconBackend.csproj
@@ -108,6 +108,7 @@
     <Compile Include="DataObjects\Post.cs" />
     <Compile Include="DataObjects\SearchResult.cs" />
     <Compile Include="DataObjects\Subreddit.cs" />
+    <Compile Include="DataObjects\SubredditAbout.cs" />
     <Compile Include="DataObjects\User.cs" />
     <Compile Include="Helpers\DeviceHelper.cs" />
     <Compile Include="Helpers\HashList.cs" />

--- a/BaconBackend/DataObjects/SubredditAbout.cs
+++ b/BaconBackend/DataObjects/SubredditAbout.cs
@@ -1,0 +1,31 @@
+﻿using BaconBackend.Collectors;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+
+namespace BaconBackend.DataObjects 
+{
+    [JsonObject(MemberSerialization.OptOut)]
+    public class SubredditAbout
+    {
+
+        /// <summary>
+        /// The reddit's "About JSON" contains the Subreddit property as a
+        /// object labeled "data"
+        /// </summary>
+        [JsonProperty(PropertyName = "data")]
+        public Subreddit SubredditInfo { get; set; }
+
+        /// <summary>
+        /// The reddit json kind string
+        /// </summary>
+        [JsonProperty(PropertyName = "kind")]
+        public string Kind { get; set; }
+    }
+}

--- a/BaconBackend/Helpers/MiscellaneousHelper.cs
+++ b/BaconBackend/Helpers/MiscellaneousHelper.cs
@@ -383,19 +383,19 @@ namespace BaconBackend.Helpers
         /// </summary>
         /// <param name="orgionalJson"></param>
         /// <returns></returns>
-        public static string ParseOutRedditDataElement(string orgionalJson)
+        public static string ParseOutRedditDataElement(string originalJson)
         {
             try
             {
                 // Try to parse out the object
-                int dataPos = orgionalJson.IndexOf("\"data\":");
+                int dataPos = originalJson.IndexOf("\"data\":");
                 if (dataPos == -1) return null;
-                int dataStartPos = orgionalJson.IndexOf('{', dataPos + 7);
+                int dataStartPos = originalJson.IndexOf('{', dataPos + 7);
                 if (dataPos == -1) return null;
-                int dataEndPos = orgionalJson.IndexOf("}", dataStartPos);
-                if (dataPos == -1) return null;
-
-                return orgionalJson.Substring(dataStartPos, (dataEndPos - dataStartPos + 1));
+                // "data" is a property of the initial object, so the substring
+                // for "data" should not have the } that closes the initial Json.
+                // The } of the original object is always the last character.
+                return originalJson.Substring(dataStartPos, (originalJson.Length - dataStartPos - 1));
             }
             catch(Exception)
             {

--- a/BaconBackend/Helpers/MiscellaneousHelper.cs
+++ b/BaconBackend/Helpers/MiscellaneousHelper.cs
@@ -381,7 +381,7 @@ namespace BaconBackend.Helpers
         /// <summary>
         /// Attempts to parse out a reddit object from a reddit data object.
         /// </summary>
-        /// <param name="orgionalJson"></param>
+        /// <param name="originalJson"></param>
         /// <returns></returns>
         public static string ParseOutRedditDataElement(string originalJson)
         {

--- a/BaconBackend/Managers/SubredditManager.cs
+++ b/BaconBackend/Managers/SubredditManager.cs
@@ -178,21 +178,16 @@ namespace BaconBackend.Managers
         /// <returns>Returns null if the subreddit get fails.</returns>
         public async Task<Subreddit> GetSubredditFromWebByDisplayName(string displayName)
         {
+            SubredditAbout subredditData = null;
             Subreddit foundSubreddit = null;
             try
             {
                 // Make the call
                 string jsonResponse = await m_baconMan.NetworkMan.MakeRedditGetRequestAsString($"/r/{displayName}/about/.json");
 
-                // Try to parse out the subreddit
-                string subredditData = MiscellaneousHelper.ParseOutRedditDataElement(jsonResponse);
-                if(subredditData == null)
-                {
-                    throw new Exception("Failed to parse out data object");
-                }
-
                 // Parse the new subreddit
-                foundSubreddit = await Task.Run(() => JsonConvert.DeserializeObject<Subreddit>(subredditData));
+                subredditData = await Task.Run(() => JsonConvert.DeserializeObject<SubredditAbout>(jsonResponse));
+                foundSubreddit = subredditData.SubredditInfo;
             }
             catch (Exception e)
             {
@@ -210,7 +205,7 @@ namespace BaconBackend.Managers
 
                 // Format the subreddit
                 foundSubreddit.Description = WebUtility.HtmlDecode(foundSubreddit.Description);
-            }        
+            }
 
             return foundSubreddit;
         }


### PR DESCRIPTION
Fixed MiscellaneousHelper.ParseOutRedditDataElement(string) for the case when there are other objects inside the JSON (other than the "data" object, thus other closing brackets). The original function would end the new json string after the first closing bracket was found, ending up with a invalid JSON string for the case when there were other closing brackets before the one closing the "data" object.

Exemple: https://www.reddit.com/r/relationships/about/.json

It was impossible to access /r/relationships duo to the malformed string generated by this function, which was causing a exception at Newtonsoft's Json Deserializer called by SubredditManager.GetSubredditFromWebByDisplayName(string), when it tried to parse this subreddit data.

However, instead of using MiscellaneousHelper.ParseOutRedditDataElement(string) to retrieve the Subreddit "data" object, the Json response was mapped to a class called SubredditAbout, allowing us to extract the actual Subreddit "data" object using Newtonsoft's Json Parser instead of direct string manipulation.

Possible solution for issue 51
https://github.com/QuinnDamerell/Baconit/issues/51