### PR TITLE
Fix for issue #57

### DIFF
--- a/BaconBackend/Collectors/CommentCollector.cs
+++ b/BaconBackend/Collectors/CommentCollector.cs
@@ -450,7 +450,7 @@ namespace BaconBackend.Collectors
                 {
                     // We fucked up adding the comment to the UI.
                     m_baconMan.MessageMan.DebugDia("Failed injecting comment", e);
-                    m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "AddCommentSuccessButAddUiFailed");
+                    m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "AddCommentSuccessButAddUiFailed");
                 }
 
                 // If we get to adding to the UI return true because reddit has the comment.
@@ -460,7 +460,7 @@ namespace BaconBackend.Collectors
             {
                 // Reddit returned something wrong
                 m_baconMan.MessageMan.ShowMessageSimple("That's not right", "Sorry we can't post your comment right now, reddit returned and unexpected message.");
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "CommentPostReturnedUnexpectedMessage");
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "CommentPostReturnedUnexpectedMessage");
                 return false;
             }
         }   

--- a/BaconBackend/Collectors/MessageCollector.cs
+++ b/BaconBackend/Collectors/MessageCollector.cs
@@ -110,7 +110,7 @@ namespace BaconBackend.Collectors
                 catch (Exception ex)
                 {
                     m_baconMan.MessageMan.DebugDia("failed to set message status!", ex);
-                    m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "failedToSetMessageRead", ex);
+                    m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "failedToSetMessageRead", ex);
                 }
             });
         }

--- a/BaconBackend/Collectors/PostCollector.cs
+++ b/BaconBackend/Collectors/PostCollector.cs
@@ -460,7 +460,7 @@ namespace BaconBackend.Collectors
                 {
                     // We fucked up updating the UI for the post edit.
                     m_baconMan.MessageMan.DebugDia("Failed updating selftext in UI", e);
-                    m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedUpdatingSelftextInUI");
+                    m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedUpdatingSelftextInUI");
                 }
 
                 // If the response was ok always return true.
@@ -470,7 +470,7 @@ namespace BaconBackend.Collectors
             {
                 // Reddit returned something wrong
                 m_baconMan.MessageMan.ShowMessageSimple("That's not right", "We can't edit your post right now, reddit returned and unexpected message.");
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "CommentPostReturnedUnexpectedMessage");
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "CommentPostReturnedUnexpectedMessage");
                 return false;
             }
         }

--- a/BaconBackend/Helpers/MiscellaneousHelper.cs
+++ b/BaconBackend/Helpers/MiscellaneousHelper.cs
@@ -182,7 +182,7 @@ namespace BaconBackend.Helpers
             }
             catch (Exception e)
             {
-                baconMan.TelemetryMan.ReportUnExpectedEvent("MisHelper", "failed to send comment", e);
+                baconMan.TelemetryMan.ReportUnexpectedEvent("MisHelper", "failed to send comment", e);
                 baconMan.MessageMan.DebugDia("failed to send message", e);
             }
             return returnString;
@@ -215,7 +215,7 @@ namespace BaconBackend.Helpers
             }
             catch (Exception e)
             {
-                baconMan.TelemetryMan.ReportUnExpectedEvent("MisHelper", "failed to search for user", e);
+                baconMan.TelemetryMan.ReportUnexpectedEvent("MisHelper", "failed to search for user", e);
                 baconMan.MessageMan.DebugDia("failed to search for user", e);
             }
             return foundUser;
@@ -246,7 +246,7 @@ namespace BaconBackend.Helpers
             }
             catch (Exception e)
             {
-                baconMan.TelemetryMan.ReportUnExpectedEvent("MisHelper", "failed to delete post", e);
+                baconMan.TelemetryMan.ReportUnexpectedEvent("MisHelper", "failed to delete post", e);
                 baconMan.MessageMan.DebugDia("failed to delete post", e);
             }
             return false;
@@ -294,13 +294,13 @@ namespace BaconBackend.Helpers
                 }
                 else
                 {
-                    baconMan.TelemetryMan.ReportUnExpectedEvent("MisHelper", "failed to save or hide item, unknown response");
+                    baconMan.TelemetryMan.ReportUnexpectedEvent("MisHelper", "failed to save or hide item, unknown response");
                     baconMan.MessageMan.DebugDia("failed to save or hide item, unknown response");
                 }
             }
             catch (Exception e)
             {
-                baconMan.TelemetryMan.ReportUnExpectedEvent("MisHelper", "failed to save or hide item", e);
+                baconMan.TelemetryMan.ReportUnexpectedEvent("MisHelper", "failed to save or hide item", e);
                 baconMan.MessageMan.DebugDia("failed to save or hide item", e);
             }
             return wasSuccess;
@@ -368,20 +368,20 @@ namespace BaconBackend.Helpers
                         string enumName = Enum.GetName(typeof(SubmitNewPostErrors), i).ToLower(); ;
                         if (responseLower.Contains(enumName))
                         {
-                            baconMan.TelemetryMan.ReportUnExpectedEvent("MisHelper", "failed to submit post; error: "+ enumName);
+                            baconMan.TelemetryMan.ReportUnexpectedEvent("MisHelper", "failed to submit post; error: "+ enumName);
                             baconMan.MessageMan.DebugDia("failed to submit post; error: "+ enumName);
                             return new SubmitNewPostResponse() { Success = false, RedditError = (SubmitNewPostErrors)i};
                         }
                     }
 
-                    baconMan.TelemetryMan.ReportUnExpectedEvent("MisHelper", "failed to submit post; unknown reddit error: ");
+                    baconMan.TelemetryMan.ReportUnexpectedEvent("MisHelper", "failed to submit post; unknown reddit error: ");
                     baconMan.MessageMan.DebugDia("failed to submit post; unknown reddit error");
                     return new SubmitNewPostResponse() { Success = false, RedditError = SubmitNewPostErrors.UNKNOWN };
                 }
             }
             catch (Exception e)
             {
-                baconMan.TelemetryMan.ReportUnExpectedEvent("MisHelper", "failed to submit post", e);
+                baconMan.TelemetryMan.ReportUnexpectedEvent("MisHelper", "failed to submit post", e);
                 baconMan.MessageMan.DebugDia("failed to submit post", e);
                 return new SubmitNewPostResponse() { Success = false };
             }
@@ -411,7 +411,7 @@ namespace BaconBackend.Helpers
             //}
             //catch (Exception e)
             //{
-            //    baconMan.TelemetryMan.ReportUnExpectedEvent("MisHelper", "failed to submit post", e);
+            //    baconMan.TelemetryMan.ReportUnexpectedEvent("MisHelper", "failed to submit post", e);
             //    baconMan.MessageMan.DebugDia("failed to submit post", e);
             //    return new SubmitNewPostResponse() { Success = false };
             //}

--- a/BaconBackend/Helpers/TrendingSubredditsHelper.cs
+++ b/BaconBackend/Helpers/TrendingSubredditsHelper.cs
@@ -140,7 +140,7 @@ namespace BaconBackend.Helpers
                 }
                 catch(Exception ex)
                 {
-                    m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "failedtoParseTrendingPost", ex);
+                    m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "failedtoParseTrendingPost", ex);
                     m_baconMan.MessageMan.DebugDia("failed to parse trending subs post", ex);
                 }
             }
@@ -167,7 +167,7 @@ namespace BaconBackend.Helpers
             }
             catch(Exception e)
             {
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "failedToFireReadyEvent", e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "failedToFireReadyEvent", e);
                 m_baconMan.MessageMan.DebugDia("failed to fire trending subs ready event", e);
             }
         }

--- a/BaconBackend/Managers/Background/BackgroundBandManager.cs
+++ b/BaconBackend/Managers/Background/BackgroundBandManager.cs
@@ -115,7 +115,7 @@ namespace BaconBackend.Managers.Background
                 catch(Exception e)
                 {
                     m_baconMan.MessageMan.DebugDia("failed to update band message", e);
-                    m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToUpdateBandMessages", e);
+                    m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToUpdateBandMessages", e);
                 }
             }
         }
@@ -188,7 +188,7 @@ namespace BaconBackend.Managers.Background
                                 if (!await bandClient.TileManager.AddTileAsync(tile))
                                 {
                                     m_baconMan.MessageMan.DebugDia("failed to create tile");
-                                    m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToCreateTileOnBand");
+                                    m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToCreateTileOnBand");
                                     wasSuccess = false;
                                 }
                             }
@@ -203,7 +203,7 @@ namespace BaconBackend.Managers.Background
                             if (!await bandClient.TileManager.RemoveTileAsync(baconitTile))
                             {
                                 m_baconMan.MessageMan.DebugDia("failed to remove tile");
-                                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToRemoveTileOnBand");
+                                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToRemoveTileOnBand");
                                 wasSuccess = false;
                             }
                         }

--- a/BaconBackend/Managers/Background/BackgroundImageUpdater.cs
+++ b/BaconBackend/Managers/Background/BackgroundImageUpdater.cs
@@ -172,7 +172,7 @@ namespace BaconBackend.Managers.Background
             catch(Exception e)
             {
                 m_baconMan.MessageMan.DebugDia("Failed to set background image", e);
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "Failed to set background image", e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "Failed to set background image", e);
             }
         }
 
@@ -216,7 +216,7 @@ namespace BaconBackend.Managers.Background
             catch (Exception e)
             {
                 m_baconMan.MessageMan.DebugDia("Failed to set background image", e);
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "Failed to set background image", e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "Failed to set background image", e);
             }
         }
 
@@ -286,7 +286,7 @@ namespace BaconBackend.Managers.Background
                     if (!wasSuccess)
                     {
                         m_baconMan.TelemetryMan.ReportLog(this, "Image update failed", SeverityLevel.Error);
-                        m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, type == UpdateTypes.LockScreen ? "LockscreenImageUpdateFailed" : "DesktopImageUpdateFailed");
+                        m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, type == UpdateTypes.LockScreen ? "LockscreenImageUpdateFailed" : "DesktopImageUpdateFailed");
                     }
                     else
                     {
@@ -460,7 +460,7 @@ namespace BaconBackend.Managers.Background
             }
             catch(Exception e)
             {
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToDeleteCacheImages", e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToDeleteCacheImages", e);
             }
 
             // Setup the vars
@@ -583,7 +583,7 @@ namespace BaconBackend.Managers.Background
                 catch (Exception e)
                 {
                     m_baconMan.MessageMan.DebugDia("Failed to write background image", e);
-                    m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "Failed to write background image", e);
+                    m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "Failed to write background image", e);
                 }
             }
 

--- a/BaconBackend/Managers/Background/BackgroundMessageUpdater.cs
+++ b/BaconBackend/Managers/Background/BackgroundMessageUpdater.cs
@@ -232,7 +232,7 @@ namespace BaconBackend.Managers.Background
             }
             catch (Exception ex)
             {
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "messageUpdaterFailed", ex);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "messageUpdaterFailed", ex);
                 m_baconMan.MessageMan.DebugDia("failed to update message notifications", ex);
             }
 

--- a/BaconBackend/Managers/Background/MessageOfTheDayManager.cs
+++ b/BaconBackend/Managers/Background/MessageOfTheDayManager.cs
@@ -121,7 +121,7 @@ namespace BaconBackend.Managers
             catch(Exception e)
             {
                 m_baconMan.MessageMan.DebugDia("failed to get motd", e);
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToGetMotd", e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToGetMotd", e);
             }
 
             return null;

--- a/BaconBackend/Managers/BackgroundManager.cs
+++ b/BaconBackend/Managers/BackgroundManager.cs
@@ -99,7 +99,7 @@ namespace BaconBackend.Managers
                     }
                     catch(Exception e)
                     {
-                        m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "failed to register background task", e);
+                        m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "failed to register background task", e);
                         m_baconMan.MessageMan.DebugDia("failed to register background task", e);
                     }
                 }

--- a/BaconBackend/Managers/DraftManager.cs
+++ b/BaconBackend/Managers/DraftManager.cs
@@ -65,7 +65,7 @@ namespace BaconBackend.Managers
             catch(Exception e)
             {
                 m_baconMan.MessageMan.DebugDia("failed to write draft", e);
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToWriteDraftFile",e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToWriteDraftFile",e);
                 return false;
             }
             return true;
@@ -98,7 +98,7 @@ namespace BaconBackend.Managers
             catch (Exception e)
             {
                 m_baconMan.MessageMan.DebugDia("failed to read draft", e);
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToReadDraftFile", e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToReadDraftFile", e);
                 return null;
             }
         }

--- a/BaconBackend/Managers/ImageManager.cs
+++ b/BaconBackend/Managers/ImageManager.cs
@@ -321,7 +321,7 @@ namespace BaconBackend.Managers
                     }
                     catch(Exception ex)
                     {
-                        m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToSaveImageLocallyCallback", ex);
+                        m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToSaveImageLocallyCallback", ex);
                         m_baconMan.MessageMan.DebugDia("failed to save image locally in callback", ex);
                     }
                 };
@@ -329,7 +329,7 @@ namespace BaconBackend.Managers
             }
             catch (Exception e)
             {
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToSaveImageLocally", e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToSaveImageLocally", e);
                 m_baconMan.MessageMan.DebugDia("failed to save image locally", e);
             }
         }

--- a/BaconBackend/Managers/MemoryManager.cs
+++ b/BaconBackend/Managers/MemoryManager.cs
@@ -285,7 +285,7 @@ namespace BaconBackend.Managers
             catch(Exception e)
             {
                 m_baconMan.MessageMan.DebugDia("Memory report fire failed", e);
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "MemeoryReportFiredFailed", e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "MemeoryReportFiredFailed", e);
             }
         }
 
@@ -309,7 +309,7 @@ namespace BaconBackend.Managers
             catch (Exception e)
             {
                 m_baconMan.MessageMan.DebugDia("Memory cleanup fire failed", e);
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "MemeoryCleanupFiredFailed", e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "MemeoryCleanupFiredFailed", e);
             }
         }
     }

--- a/BaconBackend/Managers/MessageManager.cs
+++ b/BaconBackend/Managers/MessageManager.cs
@@ -37,7 +37,7 @@ namespace BaconBackend.Managers
                 }
                 catch (Exception e)
                 {
-                    m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToShowMessage", e);
+                    m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToShowMessage", e);
                 }
             });
         }
@@ -83,7 +83,7 @@ namespace BaconBackend.Managers
                 }
                 catch(Exception e)
                 {
-                    m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToShowMessage",e);
+                    m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToShowMessage",e);
                 }
             });
         }

--- a/BaconBackend/Managers/SettingsManager.cs
+++ b/BaconBackend/Managers/SettingsManager.cs
@@ -86,7 +86,7 @@ namespace BaconBackend.Managers
             catch(Exception e)
             {
                 m_baconMan.MessageMan.DebugDia("failed to write setting " + name, e);
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "failedToWriteSetting" + name, e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "failedToWriteSetting" + name, e);
             }            
         }
 

--- a/BaconBackend/Managers/SubredditManager.cs
+++ b/BaconBackend/Managers/SubredditManager.cs
@@ -191,7 +191,7 @@ namespace BaconBackend.Managers
             }
             catch (Exception e)
             {
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "failed to get subreddit", e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "failed to get subreddit", e);
                 m_baconMan.MessageMan.DebugDia("failed to get subreddit", e);
             }
 
@@ -257,13 +257,13 @@ namespace BaconBackend.Managers
                 }
 
                 // Report the error
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToSubscribeToSubredditWebRequestFailed");
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToSubscribeToSubredditWebRequestFailed");
                 m_baconMan.MessageMan.DebugDia("failed to subscribe / unsub subreddit, reddit returned an expected value");
                 return false;
             }
             catch (Exception e)
             {
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToSubscribeToSubreddit", e);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToSubscribeToSubreddit", e);
                 m_baconMan.MessageMan.DebugDia("failed to subscribe / unsub subreddit", e);
             }
             return false;

--- a/BaconBackend/Managers/TelemetryManager.cs
+++ b/BaconBackend/Managers/TelemetryManager.cs
@@ -38,7 +38,7 @@ namespace BaconBackend.Managers
         /// Reports an event that might need to be looked at, an unexpected event.
         /// </summary>
         /// <param name="eventName"></param>
-        public void ReportUnExpectedEvent(object component, string eventName, Exception excpetion = null)
+        public void ReportUnexpectedEvent(object component, string eventName, Exception excpetion = null)
         {
             TelemetryClient client = new TelemetryClient();
             EventTelemetry eventT = new EventTelemetry();

--- a/BaconBackend/Managers/UserManager.cs
+++ b/BaconBackend/Managers/UserManager.cs
@@ -168,7 +168,7 @@ namespace BaconBackend.Managers
             catch (Exception ex)
             {
                 m_baconMan.MessageMan.DebugDia("Failed to notify user listener of update", ex);
-                m_baconMan.TelemetryMan.ReportUnExpectedEvent(this, "failed to fire OnUserUpdated", ex);
+                m_baconMan.TelemetryMan.ReportUnexpectedEvent(this, "failed to fire OnUserUpdated", ex);
             }
         }
 

--- a/Baconit/ContentPanels/ContentPanelMaster.cs
+++ b/Baconit/ContentPanels/ContentPanelMaster.cs
@@ -624,7 +624,6 @@ namespace Baconit.ContentPanels
             }
 
             IContentPanelHost restoreHost = null;
-            string restoreHostId = null;
 
             // Now actually clear the host
             lock (m_currentPanelList)
@@ -645,9 +644,6 @@ namespace Baconit.ContentPanels
                     // Get the host
                     restoreHost = element.PastHosts[0];
                     element.PastHosts.RemoveAt(0);
-
-                    // Get the ID
-                    restoreHostId = element.Source.Id;
                 }
 
                 // If we the state isn't allowed and we don't have a host to restore
@@ -659,9 +655,9 @@ namespace Baconit.ContentPanels
             }
 
             // If we have a panel to restore call register on it.
-            if(restoreHost != null && !String.IsNullOrWhiteSpace(restoreHostId))
+            if(restoreHost != null)
             {
-                RegisterForPanel(restoreHost, restoreHostId);
+                RegisterForPanel(restoreHost, panelId);
             }            
         }
 

--- a/Baconit/ContentPanels/ContentPanelMaster.cs
+++ b/Baconit/ContentPanels/ContentPanelMaster.cs
@@ -982,7 +982,7 @@ namespace Baconit.ContentPanels
                 catch (Exception e)
                 {
                     App.BaconMan.MessageMan.DebugDia("FireOnPanelAvailable failed", e);
-                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FireOnPanelAvailableFailed", e);
+                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FireOnPanelAvailableFailed", e);
                 }
             });
         }
@@ -1007,7 +1007,7 @@ namespace Baconit.ContentPanels
                 catch (Exception e)
                 {
                     App.BaconMan.MessageMan.DebugDia("FireOnRemovePanel failed", e);
-                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FireOnRemovePanelFailed", e);
+                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FireOnRemovePanelFailed", e);
                 }
             });
         }
@@ -1028,7 +1028,7 @@ namespace Baconit.ContentPanels
                 catch (Exception e)
                 {
                     App.BaconMan.MessageMan.DebugDia("FireOnRemovePanel failed", e);
-                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FireOnRemovePanelFailed", e);
+                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FireOnRemovePanelFailed", e);
                 }
             });
         }
@@ -1051,7 +1051,7 @@ namespace Baconit.ContentPanels
                 catch (Exception e)
                 {
                     App.BaconMan.MessageMan.DebugDia("FireOnContentPreloading failed", e);
-                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FireOnContentPreloadingFailed", e);
+                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FireOnContentPreloadingFailed", e);
                 }
             });
         }
@@ -1073,7 +1073,7 @@ namespace Baconit.ContentPanels
                 catch (Exception e)
                 {
                     App.BaconMan.MessageMan.DebugDia("FireOnPanelUnloaded failed", e);
-                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FireOnPanelUnloadedFailed", e);
+                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FireOnPanelUnloadedFailed", e);
                 }
             });
         }

--- a/Baconit/ContentPanels/Panels/BasicImageContentPanel.xaml.cs
+++ b/Baconit/ContentPanels/Panels/BasicImageContentPanel.xaml.cs
@@ -153,7 +153,7 @@ namespace Baconit.ContentPanels.Panels
                 if (String.IsNullOrWhiteSpace(imageUrl))
                 {
                     // This is bad, we should be able to get the url.
-                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "BasicImageControlNoImageUrl");
+                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "BasicImageControlNoImageUrl");
 
                     // Jump back to the UI thread
                     m_base.FireOnFallbackToBrowser();
@@ -254,7 +254,7 @@ namespace Baconit.ContentPanels.Panels
             {
                 if (!response.Success)
                 {
-                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "BasicImageControlNoImageUrl");
+                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "BasicImageControlNoImageUrl");
                     m_base.FireOnFallbackToBrowser();
                     return;
                 }

--- a/Baconit/ContentPanels/Panels/ContentPanelBase.cs
+++ b/Baconit/ContentPanels/Panels/ContentPanelBase.cs
@@ -313,7 +313,7 @@ namespace Baconit.ContentPanels.Panels
                 {
                     // If we fail here we will fall back to the web browser.
                     App.BaconMan.MessageMan.DebugDia("Failed to query can handle post", e);
-                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToQueryCanHandlePost", e);
+                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToQueryCanHandlePost", e);
                 }
             }
 
@@ -336,7 +336,7 @@ namespace Baconit.ContentPanels.Panels
                         loadedPanel = false;
                         HasError = true;
                         App.BaconMan.MessageMan.DebugDia("failed to create content control", e);
-                        App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToCreateContentPanel", e);
+                        App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToCreateContentPanel", e);
                     }
                 });
             }

--- a/Baconit/ContentPanels/Panels/GifImageContentPanel.xaml.cs
+++ b/Baconit/ContentPanels/Panels/GifImageContentPanel.xaml.cs
@@ -105,7 +105,7 @@ namespace Baconit.ContentPanels.Panels
                     if (String.IsNullOrWhiteSpace(gifUrl))
                     {
                         m_base.FireOnFallbackToBrowser();
-                        App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToShowGifAfterConfirm");
+                        App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToShowGifAfterConfirm");
                         return;
                     }
 
@@ -382,7 +382,7 @@ namespace Baconit.ContentPanels.Panels
             catch (Exception e)
             {
                 App.BaconMan.MessageMan.DebugDia("failed to get image from gfycat", e);
-                App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FaileGfyCatApiCall", e);
+                App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FaileGfyCatApiCall", e);
             }
 
             return String.Empty;
@@ -441,7 +441,7 @@ namespace Baconit.ContentPanels.Panels
             catch (Exception e)
             {
                 App.BaconMan.MessageMan.DebugDia("failed to convert gif via gfycat", e);
-                App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "GfyCatConvertFailed", e);
+                App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "GfyCatConvertFailed", e);
             }
 
             return String.Empty;

--- a/Baconit/ContentPanels/Panels/MarkdownContentPanel.xaml.cs
+++ b/Baconit/ContentPanels/Panels/MarkdownContentPanel.xaml.cs
@@ -136,7 +136,7 @@ namespace Baconit.ContentPanels.Panels
             if (e.WasError)
             {
                 m_base.FireOnFallbackToBrowser();
-                App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToShowMarkdown", e.Exception);
+                App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToShowMarkdown", e.Exception);
             }
             else
             {

--- a/Baconit/ContentPanels/Panels/RedditContentPanel.xaml.cs
+++ b/Baconit/ContentPanels/Panels/RedditContentPanel.xaml.cs
@@ -123,7 +123,7 @@ namespace Baconit.ContentPanels.Panels
                         case RedditContentType.Website:
                             // This shouldn't happen
                             App.BaconMan.MessageMan.DebugDia("Got website back when prepare on reddit content control");
-                            App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "GotWebsiteOnPrepareRedditContent");
+                            App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "GotWebsiteOnPrepareRedditContent");
                             break;
                     }
                 }

--- a/Baconit/ContentPanels/Panels/WebPageContentPanel.xaml.cs
+++ b/Baconit/ContentPanels/Panels/WebPageContentPanel.xaml.cs
@@ -141,7 +141,7 @@ namespace Baconit.ContentPanels.Panels
             }
             catch (Exception e)
             {
-                App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToMakeUriInWebControl", e);
+                App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToMakeUriInWebControl", e);
                 m_base.FireOnError(true, "This web page failed to load");
             }
 
@@ -225,7 +225,7 @@ namespace Baconit.ContentPanels.Panels
             }
             catch (Exception ex)
             {
-                App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToNavReadingMode", ex);
+                App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToNavReadingMode", ex);
             }
 
             App.BaconMan.TelemetryMan.ReportEvent(this, "ReadingModeEnabled");

--- a/Baconit/ContentPanels/Panels/YoutubeContentPanel.xaml.cs
+++ b/Baconit/ContentPanels/Panels/YoutubeContentPanel.xaml.cs
@@ -94,7 +94,7 @@ namespace Baconit.ContentPanels.Panels
                     {
                         // If we failed fallback to the browser.
                         m_base.FireOnFallbackToBrowser();
-                        App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToGetYoutubeVideoAfterSuccess");
+                        App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToGetYoutubeVideoAfterSuccess");
                         return;
                     }
 

--- a/Baconit/HelperControls/CommentBox.xaml.cs
+++ b/Baconit/HelperControls/CommentBox.xaml.cs
@@ -375,7 +375,7 @@ namespace Baconit.HelperControls
                 catch (Exception ex)
                 {
                     App.BaconMan.MessageMan.DebugDia("failed to fire OnCommentSubmitted", ex);
-                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "OnCommentSubmittedFireFailed", ex);
+                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "OnCommentSubmittedFireFailed", ex);
                 }
             }
             else

--- a/Baconit/HelperControls/MotdPopUp.xaml.cs
+++ b/Baconit/HelperControls/MotdPopUp.xaml.cs
@@ -112,7 +112,7 @@ namespace Baconit.HelperControls
             }
             catch (Exception ex)
             {
-                App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "MOTDLinkFailedToOpen", ex);
+                App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "MOTDLinkFailedToOpen", ex);
                 App.BaconMan.MessageMan.DebugDia("MOTDLinkFailedToOpen", ex);
             }
         }

--- a/Baconit/MainPage.xaml.cs
+++ b/Baconit/MainPage.xaml.cs
@@ -357,7 +357,7 @@ namespace Baconit
             }
             catch(Exception e)
             {
-                App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "UpdateSubredditListFailed", e);
+                App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "UpdateSubredditListFailed", e);
                 App.BaconMan.MessageMan.DebugDia("UpdateSubredditListFailed", e);
             }
         }

--- a/Baconit/MainPage.xaml.cs
+++ b/Baconit/MainPage.xaml.cs
@@ -162,10 +162,15 @@ namespace Baconit
                 defaultDisplayName = m_subredditFirstNavOverwrite;
             }
 
+            SortTypes defaultSortType = App.BaconMan.UiSettingsMan.SubredditList_DefaultSortType;
+            SortTimeTypes defaultSortTime = App.BaconMan.UiSettingsMan.SubredditList_DefaultSortTimeType;
+
             // Navigate to the start
             Dictionary<string, object> args = new Dictionary<string, object>();
             args.Add(PanelManager.NAV_ARGS_SUBREDDIT_NAME, defaultDisplayName);
-            m_panelManager.Navigate(typeof(SubredditPanel), defaultDisplayName + SortTypes.Hot + SortTimeTypes.Week, args);
+            args.Add(PanelManager.NAV_ARGS_SUBREDDIT_SORT, defaultSortType);
+            args.Add(PanelManager.NAV_ARGS_SUBREDDIT_SORT_TIME, defaultSortTime);
+            m_panelManager.Navigate(typeof(SubredditPanel), defaultDisplayName + defaultSortType + defaultSortTime, args);
             m_panelManager.Navigate(typeof(WelcomePanel), "WelcomePanel");
 
             // Update the trending subreddits
@@ -826,9 +831,15 @@ namespace Baconit
         /// <param name="subreddit"></param>
         private void NavigateToSubreddit(Subreddit subreddit)
         {
+            SortTypes defaultSortType = App.BaconMan.UiSettingsMan.SubredditList_DefaultSortType;
+            SortTimeTypes defaultSortTime = App.BaconMan.UiSettingsMan.SubredditList_DefaultSortTimeType;
+
             Dictionary<string, object> args = new Dictionary<string, object>();
             args.Add(PanelManager.NAV_ARGS_SUBREDDIT_NAME, subreddit.DisplayName.ToLower());
-            m_panelManager.Navigate(typeof(SubredditPanel), subreddit.GetNavigationUniqueId(SortTypes.Hot, SortTimeTypes.Week), args);
+            args.Add(PanelManager.NAV_ARGS_SUBREDDIT_SORT, defaultSortType);
+            args.Add(PanelManager.NAV_ARGS_SUBREDDIT_SORT_TIME, defaultSortTime);
+            
+            m_panelManager.Navigate(typeof(SubredditPanel), subreddit.GetNavigationUniqueId(defaultSortType, defaultSortTime), args);
         }
 
         #endregion

--- a/Baconit/Package.appxmanifest
+++ b/Baconit/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="9020QuinnDamerell.Baconit" Publisher="CN=0E9109BC-07EF-4673-BFC9-D5C280E44460" Version="4.8.3.0" />
+  <Identity Name="9020QuinnDamerell.Baconit" Publisher="CN=0E9109BC-07EF-4673-BFC9-D5C280E44460" Version="4.8.7.0" />
   <mp:PhoneIdentity PhoneProductId="a941e755-1dc4-4a35-9f20-ca3d8d0beaaa" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Baconit</DisplayName>

--- a/Baconit/Package.appxmanifest
+++ b/Baconit/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="9020QuinnDamerell.Baconit" Publisher="CN=0E9109BC-07EF-4673-BFC9-D5C280E44460" Version="4.8.7.0" />
+  <Identity Name="9020QuinnDamerell.Baconit" Publisher="CN=0E9109BC-07EF-4673-BFC9-D5C280E44460" Version="4.8.10.0" />
   <mp:PhoneIdentity PhoneProductId="a941e755-1dc4-4a35-9f20-ca3d8d0beaaa" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Baconit</DisplayName>
@@ -27,23 +27,23 @@
         <uap:SplashScreen Image="Assets\AppAssets\SplashScreen\Splash.png" BackgroundColor="transparent" />
       </uap:VisualElements>
       <Extensions>
-        <uap:Extension Category="windows.protocol">
-          <uap:Protocol Name="baconit">
-            <uap:Logo>Assets\AppAssets\Square44x44\Square44.png</uap:Logo>
-            <uap:DisplayName>Baconit</uap:DisplayName>
-          </uap:Protocol>
-        </uap:Extension>
+        <Extension Category="windows.backgroundTasks" EntryPoint="BaconBackground.BackgroundEntry">
+          <BackgroundTasks>
+            <Task Type="timer" />
+          </BackgroundTasks>
+        </Extension>
         <uap:Extension Category="windows.protocol">
           <uap:Protocol Name="reddit">
             <uap:Logo>Assets\AppAssets\Square44x44\Square44.png</uap:Logo>
             <uap:DisplayName>Baconit</uap:DisplayName>
           </uap:Protocol>
         </uap:Extension>
-        <Extension Category="windows.backgroundTasks" EntryPoint="BaconBackground.BackgroundEntry">
-          <BackgroundTasks>
-            <Task Type="timer" />
-          </BackgroundTasks>
-        </Extension>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="baconit">
+            <uap:Logo>Assets\AppAssets\Square44x44\Square44.png</uap:Logo>
+            <uap:DisplayName>Baconit</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/Baconit/PanelManager.xaml.cs
+++ b/Baconit/PanelManager.xaml.cs
@@ -1014,7 +1014,7 @@ namespace Baconit
                 // Check that we are good.
                 if (currentPanel == null)
                 {
-                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "MemoryCleanupCurrentPanelNull");
+                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "MemoryCleanupCurrentPanelNull");
                     return;
                 }
 

--- a/Baconit/Panels/FlipView/FlipViewPanel.xaml.cs
+++ b/Baconit/Panels/FlipView/FlipViewPanel.xaml.cs
@@ -443,7 +443,7 @@ namespace Baconit.Panels.FlipView
                                     }
                                     catch (Exception e)
                                     {
-                                        App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "mPostListAddFailedSpot1", e);
+                                        App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "mPostListAddFailedSpot1", e);
                                         App.BaconMan.MessageMan.DebugDia("Adding to m_postList failed! " + (post == null ? "post was null!" : "post IS NOT NULL"), e);
                                     }
                                 }
@@ -462,7 +462,7 @@ namespace Baconit.Panels.FlipView
                                 }
                                 catch(Exception e)
                                 {
-                                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "mPostListAddFailedSpot2", e);
+                                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "mPostListAddFailedSpot2", e);
                                     App.BaconMan.MessageMan.DebugDia("Adding to m_postList failed! " + (post == null ? "post was null!" : "post IS NOT NULL"), e);
                                 }
                             }

--- a/Baconit/Panels/FlipView/FlipViewPostCommentManager.cs
+++ b/Baconit/Panels/FlipView/FlipViewPostCommentManager.cs
@@ -631,7 +631,7 @@ namespace Baconit.Panels
             else
             {
                 args.Request.FailWithDisplayText("Baconit doesn't have anything to share!");
-                App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "FailedToShareCommentHelperCommentNoShareComment");
+                App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "FailedToShareCommentHelperCommentNoShareComment");
             }
         }
 

--- a/Baconit/Panels/LoginPanel.xaml.cs
+++ b/Baconit/Panels/LoginPanel.xaml.cs
@@ -117,7 +117,7 @@ namespace Baconit.Panels
                 else
                 {
                     App.BaconMan.MessageMan.ShowMessageSimple("Something Went Wrong", "We can't log you in right now, try again later.");
-                    App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "LoginFailedUnknown");
+                    App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "LoginFailedUnknown");
                 }
             }
         }

--- a/Baconit/Panels/MessageInbox.xaml.cs
+++ b/Baconit/Panels/MessageInbox.xaml.cs
@@ -250,7 +250,7 @@ namespace Baconit.Panels
             {
                 App.BaconMan.MessageMan.DebugDia("failed to parse message context", ex);
                 App.BaconMan.MessageMan.ShowMessageSimple("Oops", "Something is wrong and we can't show this context right now.");
-                App.BaconMan.TelemetryMan.ReportUnExpectedEvent(this, "failedToParseMessageContextString", ex);
+                App.BaconMan.TelemetryMan.ReportUnexpectedEvent(this, "failedToParseMessageContextString", ex);
                 return;
             }
 


### PR DESCRIPTION
This fixes issue #57 Can't filter for "Hot". The issue was basically that, when navigating to a subreddit, the id getting passed into the `.Navigate(...)` method was always "funnyHotWeek" (assuming you're navigating to /r/funny). If you had switched the default sort type in your settings (to "new" in this case), the panel would behave as if it was "funnyNewWeek". When you would then go to change the sort to "hot", the `.Navigate(...)` method would think that you're trying to go _from_ "funnyHotWeek" _to_ "funnyHotWeek" and it would basically do nothing, if that makes sense. 

There might be a cleaner way to do it. There's probably not really a need to pass in the sort arguments in both of those places that were changed, since they would end up as the default anyway, so I can always reverse that if need be.

I merged master into the develop branch. I can always reverse that merge to separate just my changes if that works better. 

Let me know! Thanks!