### PR TITLE
To avoid issues with HTML-encoded strings, request the raw JSON form of results from the Reddit API.

### DIFF
--- a/BaconBackend/Collectors/CommentCollector.cs
+++ b/BaconBackend/Collectors/CommentCollector.cs
@@ -190,10 +190,6 @@ namespace BaconBackend.Collectors
                 DateTime postTime = origin.AddSeconds(comment.CreatedUtc).ToLocalTime();
                 comment.TimeString = TimeToTextHelper.TimeElapseToText(postTime) + " ago";
 
-                // Decode the body
-                comment.Body = WebUtility.HtmlDecode(comment.Body);
-                comment.AuthorFlairText = WebUtility.HtmlDecode(comment.AuthorFlairText);
-
                 // Set if this post is from the op
                 comment.IsCommentFromOp = m_post != null && comment.Author.Equals(m_post.Author);
 

--- a/BaconBackend/Collectors/MessageCollector.cs
+++ b/BaconBackend/Collectors/MessageCollector.cs
@@ -35,10 +35,6 @@ namespace BaconBackend.Collectors
         {
             foreach(Message message in messages)
             {
-                // Decode
-                message.Subject = WebUtility.HtmlDecode(message.Subject);
-                message.Body = WebUtility.HtmlDecode(message.Body);
-
                 // Set the first line
                 message.HeaderFirst = message.Subject;
 

--- a/BaconBackend/Collectors/PostCollector.cs
+++ b/BaconBackend/Collectors/PostCollector.cs
@@ -570,14 +570,6 @@ namespace BaconBackend.Collectors
                 // Set the second line for flipview
                 post.FlipViewSecondary = showSubreddit ? $"r/{post.Subreddit.ToLower()}" : TimeToTextHelper.TimeElapseToText(postTime) + " ago";
 
-                // Escape the title, flair, and selftext
-                post.Title = WebUtility.HtmlDecode(post.Title);
-                post.LinkFlairText = WebUtility.HtmlDecode(post.LinkFlairText);
-                if (!String.IsNullOrEmpty(post.Selftext))
-                {
-                    post.Selftext = WebUtility.HtmlDecode(post.Selftext);
-                }
-
                 // Set the title size
                 post.TitleMaxLines = m_baconMan.UiSettingsMan.SubredditList_ShowFullTitles ? 99 : 2;
 

--- a/BaconBackend/Collectors/SearchPostCollector.cs
+++ b/BaconBackend/Collectors/SearchPostCollector.cs
@@ -88,9 +88,6 @@ namespace BaconBackend.Collectors
         {
             foreach (Post post in posts)
             {
-                // Do some simple formatting
-                post.Title = WebUtility.HtmlDecode(post.Title);
-
                 // Set The time
                 DateTime origin = new DateTime(1970, 1, 1, 0, 0, 0, 0);
                 DateTime postTime = origin.AddSeconds(post.CreatedUtc).ToLocalTime();

--- a/BaconBackend/Collectors/SearchSubredditCollector.cs
+++ b/BaconBackend/Collectors/SearchSubredditCollector.cs
@@ -34,8 +34,7 @@ namespace BaconBackend.Collectors
             foreach (Subreddit subreddit in subreddits)
             {
                 // Do some simple formatting
-                subreddit.Title = WebUtility.HtmlDecode(subreddit.Title);
-                subreddit.PublicDescription = WebUtility.HtmlDecode(subreddit.PublicDescription.Trim());
+                subreddit.PublicDescription =subreddit.PublicDescription.Trim();
 
                 // Do a quick and dirty replace for double new lines. This doesn't work for triple or tabs.
                 subreddit.PublicDescription = subreddit.PublicDescription.Replace("\n\n", "\n");

--- a/BaconBackend/Helpers/RedditListHelper.cs
+++ b/BaconBackend/Helpers/RedditListHelper.cs
@@ -261,7 +261,7 @@ namespace BaconBackend.Helpers
         private async Task<IHttpContent> MakeRequest(int limit, string after)
         {
             string optionalEnding = String.IsNullOrWhiteSpace(m_optionalGetArgs) ? String.Empty : "&"+ m_optionalGetArgs;
-            string url = m_baseUrl + $"?limit={limit}" + (String.IsNullOrWhiteSpace(after) ? "" : $"&after={after}") + optionalEnding;
+            string url = m_baseUrl + $"?limit={limit}" + "&raw_json=1" + (String.IsNullOrWhiteSpace(after) ? "" : $"&after={after}") + optionalEnding;
             return await m_networkMan.MakeRedditGetRequest(url);
         }
     }

--- a/BaconBackend/Managers/SubredditManager.cs
+++ b/BaconBackend/Managers/SubredditManager.cs
@@ -202,9 +202,6 @@ namespace BaconBackend.Managers
                 {
                     m_tempSubredditCache.Add(foundSubreddit);
                 }
-
-                // Format the subreddit
-                foundSubreddit.Description = WebUtility.HtmlDecode(foundSubreddit.Description);
             }
 
             return foundSubreddit;
@@ -401,9 +398,6 @@ namespace BaconBackend.Managers
             {
                 // Mark if it is a favorite
                 subreddit.IsFavorite = FavoriteSubreddits.ContainsKey(subreddit.Id);
-
-                // Escape the description, we need to do it twice because sometimes it is double escaped.
-                subreddit.Description = WebUtility.HtmlDecode(subreddit.Description);
 
                 // Do a simple inert sort, account for favorites
                 bool wasAdded = false;

--- a/Baconit/ContentPanels/Panels/YoutubeContentPanel.xaml.cs
+++ b/Baconit/ContentPanels/Panels/YoutubeContentPanel.xaml.cs
@@ -244,8 +244,7 @@ namespace Baconit.ContentPanels.Panels
             {
                 // Try to find the ID
                 string youtubeVideoId = String.Empty;
-                string postUrl = WebUtility.HtmlDecode(source.Url);
-                string urlLower = postUrl.ToLower();
+                string urlLower = source.Url.ToLower();
                 if (urlLower.Contains("youtube.com"))
                 {
                     // Check for an attribution link
@@ -255,9 +254,9 @@ namespace Baconit.ContentPanels.Panels
                         // We need to parse out the video id
                         // looks like this attribution_link?a=bhvqtDGQD6s&amp;u=%2Fwatch%3Fv%3DrK0D1ehO7CA%26feature%3Dshare
                         int uIndex = urlLower.IndexOf("u=", attribution);
-                        string encodedUrl = postUrl.Substring(uIndex + 2);
-                        postUrl = WebUtility.UrlDecode(encodedUrl);
-                        urlLower = postUrl.ToLower();
+                        string encodedUrl = source.Url.Substring(uIndex + 2);
+                        string decodedUrl = WebUtility.UrlDecode(encodedUrl);
+                        urlLower = decodedUrl.ToLower();
                         // At this point urlLower should be something like "v=jfkldfjl&feature=share"
                     }
 
@@ -271,7 +270,7 @@ namespace Baconit.ContentPanels.Panels
                         }
                         // Important! Since this might be case sensitive use the original url!
                         beginId += 2;
-                        youtubeVideoId = postUrl.Substring(beginId, endId - beginId);
+                        youtubeVideoId = source.Url.Substring(beginId, endId - beginId);
                     }
                 }
                 else if (urlLower.Contains("youtu.be"))
@@ -293,7 +292,7 @@ namespace Baconit.ContentPanels.Panels
                         }
                         // Important! Since this might be case sensitive use the original url!
                         beginId++;
-                        youtubeVideoId = postUrl.Substring(beginId, endId - beginId);
+                        youtubeVideoId = source.Url.Substring(beginId, endId - beginId);
                     }
                 }
 


### PR DESCRIPTION
This PR intends to address issue #72 by changing how Baconit accesses the Reddit APIs.

Previously, requests were presented in an HTML-encoded form. To address this, calls to decode those encoded strings were sprinkled throughout the sources, but URLs were never decoded. This had the unfortunate side effect of breaking a great many sites, including any images hosted on Reddit's own new image uploading service. To address this issue, this change modifies all calls made to the Reddit API to use raw JSON, instead of HTML-encoded responses received, and also removes the previously-required calls to decode strings that would have been unnecessarily encoded.