### PR TITLE
HTML decode post URL to fix #72

### DIFF
--- a/BaconBackend/Collectors/PostCollector.cs
+++ b/BaconBackend/Collectors/PostCollector.cs
@@ -570,7 +570,9 @@ namespace BaconBackend.Collectors
                 // Set the second line for flipview
                 post.FlipViewSecondary = showSubreddit ? $"r/{post.Subreddit.ToLower()}" : TimeToTextHelper.TimeElapseToText(postTime) + " ago";
 
-                // Escape the title, flair, and selftext
+                // HTML Decode url, title, flair, and selftext. Does anything else need decoding?
+                // Adding raw_json=1 parameter to requests may be a better alternative.
+                post.Url = WebUtility.HtmlDecode(post.Url);
                 post.Title = WebUtility.HtmlDecode(post.Title);
                 post.LinkFlairText = WebUtility.HtmlDecode(post.LinkFlairText);
                 if (!String.IsNullOrEmpty(post.Selftext))


### PR DESCRIPTION
I believe the approach in #73 is better approach, but that pull request needs more work, removing other WebUtility.HtmlDecode() calls elsewhere. Since I had this done already, I'm submitting a pull request anyways. A quick fix for this little annoying issue would be nice.