### PR TITLE
Set image source after setting decode size to fix #71

### DIFF
--- a/Baconit/ContentPanels/Panels/BasicImageContentPanel.xaml.cs
+++ b/Baconit/ContentPanels/Panels/BasicImageContentPanel.xaml.cs
@@ -347,10 +347,6 @@ namespace Baconit.ContentPanels.Panels
             bitmapImage.ImageOpened += BitmapImage_ImageOpened;
             bitmapImage.ImageFailed += BitmapImage_ImageFailed;
 
-            // Set the source.
-            stream.Seek(0);
-            bitmapImage.SetSource(stream);
-
             // Get the decode height and width.
             int decodeWidth = 0;
             int decodeHeight = 0;
@@ -378,6 +374,10 @@ namespace Baconit.ContentPanels.Panels
             // But since this is scaled, the control size is something like 3 physical pixels for each logical pixel, so the image is lower res
             // if we use physical.
             bitmapImage.DecodePixelType = App.BaconMan.MemoryMan.MemoryPressure < MemoryPressureStates.Medium ? DecodePixelType.Logical : DecodePixelType.Physical;
+
+            // Set the source. This must be done after setting decode size and other parameters, so those are respected.
+            stream.Seek(0);
+            bitmapImage.SetSource(stream);
 
             // Destroy the old image.
             if (m_image.Source != null)


### PR DESCRIPTION
Images were decoding at full size despite setting decode size.
This seems to be because the source was set first, so the image
could decode before decode size was set.

It seems the intent was to initially display images scaled to fit, but images were decoding at full size because the source was set before the decode sizes. In Microsoft's example, the source is set after, and setting the source after fixes the problem. There may have been a race condition here, because images were sometimes displayed scaled to fit initially.

With this change the behaviour is:

Images always load scaled to fit initially. Control + mouse wheel up goes to a 1:1 view where I can zoom in and out smoothly via Control + mouse wheel. If I zoom out until the image fits, it goes back to the initial state.
