### PR TITLE
Fix problem with <, > and & being xml encoded in urls

### DIFF
--- a/BaconBackend/Helpers/RedditListHelper.cs
+++ b/BaconBackend/Helpers/RedditListHelper.cs
@@ -261,7 +261,8 @@ namespace BaconBackend.Helpers
         private async Task<IHttpContent> MakeRequest(int limit, string after)
         {
             string optionalEnding = String.IsNullOrWhiteSpace(m_optionalGetArgs) ? String.Empty : "&"+ m_optionalGetArgs;
-            string url = m_baseUrl + $"?limit={limit}" + (String.IsNullOrWhiteSpace(after) ? "" : $"&after={after}") + optionalEnding;
+            string url = m_baseUrl + $"?limit={limit}" + (String.IsNullOrWhiteSpace(after) ? "" : $"&after={after}") +
+                "&raw_json=1" + optionalEnding;
             return await m_networkMan.MakeRedditGetRequest(url);
         }
     }


### PR DESCRIPTION
Reddit's api xml encodes <, > and & in urls in returned data by default. If you add raw_json=1 to the request url, this doesn't happen. This is breaking any sites which use a & in the url such as reddituploads.com.