### PR TITLE
Fetching saved items breaks when there are comments

### DIFF
--- a/BaconBackend/Collectors/PostCollector.cs
+++ b/BaconBackend/Collectors/PostCollector.cs
@@ -115,6 +115,7 @@ namespace BaconBackend.Collectors
                 {
                     // Special case for the saved posts
                     postCollectionUrl = $"/user/{m_baconMan.UserMan.CurrentUser.Name}/saved/.json";
+                    optionalArgs = "type=links";
                 }
                 else if (!String.IsNullOrWhiteSpace(collectorContext.forcePostId))
                 {


### PR DESCRIPTION
Requesting /user/username/saved/.json returns links and comments. Any comments are causing PostCollector to throw a NullReferenceException and prevents any saved posts from showing.  
Adding ?type=links to the url means only posts are returned and makes everyone happy!